### PR TITLE
fixed README: copy cronjob to /etc/cron.d instead of /etc/init.d 

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ README:
 
 Then copy the following configuration files:
 
-    sudo cp sample/atticmatic.cron /etc/init.d/atticmatic
+    sudo cp sample/atticmatic.cron /etc/cron.d/atticmatic
     sudo cp sample/config sample/excludes /etc/atticmatic/
 
 Lastly, modify those files with your desired configuration.


### PR DESCRIPTION
...like the comment in sample/atticmatic.cron correctly explains
