### PR TITLE
Add randomized delay to systemd timer

### DIFF
--- a/sample/systemd/borgmatic.timer
+++ b/sample/systemd/borgmatic.timer
@@ -4,6 +4,7 @@ Description=Run borgmatic backup
 [Timer]
 OnCalendar=daily
 Persistent=true
+RandomizedDelaySec=3h
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
`OnCalendar=daily` will always run the timer at midnight. This is not ideal in some scenarios such as if it's being executed on a virtual server, as multiple virtual servers on the same host may all start hitting the disk at the same time, resulting in much worse disk performance compared to spreading them all out.

The 'traditional' way of avoiding this on Debian was using `/etc/cron.daily` for daily jobs. The cron package has a post-install script which adds `cron.daily`, `cron.weekly` and `cron.monthly` to `/etc/crontab`  with a random start time for each.

The more modern approach is using the `RandomizedDelaySec` systemd option. This will randomly stagger the start time of the timer. For example, `RandomizedDelaySec=1h` means that the timer can start anywhere between the `OnCalendar` time and one hour later.

I've modified the `borgmatic.timer` example to use a randomized delay of 3 hours, meaning it'll run between midnight and 3:00 AM instead of always running at midnight.