### PR TITLE
TypeError with --json argument and dump SQL db

### DIFF
--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -307,7 +307,7 @@ def create_archive(
     )
 
     if json:
-        output_log_level = None
+        output_log_level = 0
     elif (stats or files) and logger.getEffectiveLevel() == logging.WARNING:
         output_log_level = logging.WARNING
     else:


### PR DESCRIPTION
With --json option and mysql dump database TypeError appear : 
Traceback (most recent call last):
  File "/opt/borgmatic/bin/borgmatic", line 8, in <module>
    sys.exit(main())
  File "/opt/borgmatic/lib/python3.8/site-packages/borgmatic/commands/borgmatic.py", line 920, in main
    summary_logs = parse_logs + list(collect_configuration_run_summary_logs(configs, arguments))
  File "/opt/borgmatic/lib/python3.8/site-packages/borgmatic/commands/borgmatic.py", line 813, in collect_configuration_run_summary_logs
    results = list(run_configuration(config_filename, config, arguments))
  File "/opt/borgmatic/lib/python3.8/site-packages/borgmatic/commands/borgmatic.py", line 114, in run_configuration
    yield from run_actions(
  File "/opt/borgmatic/lib/python3.8/site-packages/borgmatic/commands/borgmatic.py", line 350, in run_actions
    json_output = borg_create.create_archive(
  File "/opt/borgmatic/lib/python3.8/site-packages/borgmatic/borg/create.py", line 323, in create_archive
    return execute_command_with_processes(
  File "/opt/borgmatic/lib/python3.8/site-packages/borgmatic/execute.py", line 262, in execute_command_with_processes
    log_outputs(
  File "/opt/borgmatic/lib/python3.8/site-packages/borgmatic/execute.py", line 102, in log_outputs
    logger.log(output_log_level, line)
  File "/usr/lib/python3.8/logging/__init__.py", line 1508, in log
    raise TypeError("level must be an integer")
TypeError: level must be an integer