### PR TITLE
specify pg dump/restore commands (#311)

### DIFF
--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -764,6 +764,32 @@ properties:
                             description: |
                                 Path to a certificate revocation list.
                             example: "/root/.postgresql/root.crl"
+                        pg_dump_command:
+                            type: string
+                            description: |
+                                Command to use instead of "pg_dump" or
+                                "pg_dumpall". This can be used to run a specific
+                                pg_dump version (e.g., one inside a running
+                                docker container). Defaults to "pg_dump" for
+                                single database dump or "pg_dumpall" to dump
+                                all databases.
+                            example: docker exec my_pg_container pg_dump
+                        pg_restore_command:
+                            type: string
+                            description: |
+                                Command to use instead of "pg_restore". This
+                                can be used to run a specific pg_restore
+                                version (e.g., one inside a running docker
+                                container). Defaults to "pg_restore".
+                            example: docker exec my_pg_container pg_restore
+                        psql_command:
+                            type: string
+                            description: |
+                                Command to use instead of "psql". This can be
+                                used to run a specific psql version (e.g.,
+                                one inside a running docker container).
+                                Defaults to "psql".
+                            example: docker exec my_pg_container psql
                         options:
                             type: string
                             description: |


### PR DESCRIPTION
add `pg_dump_command`, `pg_restore_command` and `psql_command` configuration options. In this way, users can specify alternative commands on a per-database basis.

This is convenient if one needs to do backup/restore of different versions of postgres. A concrete example is the use of different versions of postgres running in docker containers for which one would want to use commands inside these containers while still being able to use pipes. Example:
```yaml
hooks:
  postgresql_databases:
    - name: my_pg_database
      pg_dump_command: docker exec my_pg_database pg_dump
      pg_restore_command: docker exec my_pg_database pg_restore
      psql_command: docker exec my_pg_database psql
```

It partially fixes (#311) since it's just for the postgres hook.