### PR TITLE
fix: no error on database backups without source dirs

### DIFF
--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -291,6 +291,7 @@ def collect_special_file_paths(
         capture_stderr=True,
         working_directory=working_directory,
         extra_environment=borg_environment,
+        raise_on_exit_code_one=False,
     )
 
     paths = tuple(

--- a/tests/unit/test_execute.py
+++ b/tests/unit/test_execute.py
@@ -239,6 +239,32 @@ def test_execute_command_and_capture_output_with_capture_stderr_returns_stderr()
     assert output == expected_output
 
 
+def test_execute_command_and_capture_output_returns_output_with_raise_on_exit_code_one_false():
+    full_command = ['foo', 'bar']
+    expected_output = '[]'
+    err_output = b'[]'
+    flexmock(module.os, environ={'a': 'b'})
+    flexmock(module.subprocess).should_receive('check_output').with_args(
+        full_command, stderr=None, shell=False, env=None, cwd=None
+    ).and_raise(subprocess.CalledProcessError(1, full_command, err_output)).once()
+
+    output = module.execute_command_and_capture_output(full_command, raise_on_exit_code_one=False)
+
+    assert output == expected_output
+
+
+def test_execute_command_and_capture_output_returns_output_with_raise_on_exit_code_one_false_and_exit_code_not_one():
+    full_command = ['foo', 'bar']
+    expected_output = '[]'
+    flexmock(module.os, environ={'a': 'b'})
+    flexmock(module.subprocess).should_receive('check_output').with_args(
+        full_command, stderr=None, shell=False, env=None, cwd=None
+    ).and_raise(subprocess.CalledProcessError(2, full_command, expected_output)).once()
+
+    with pytest.raises(subprocess.CalledProcessError):
+        module.execute_command_and_capture_output(full_command, raise_on_exit_code_one=False)
+
+
 def test_execute_command_and_capture_output_returns_output_with_shell():
     full_command = ['foo', 'bar']
     expected_output = '[]'


### PR DESCRIPTION
Your detailed explanation in [#655](https://projects.torsion.org/borgmatic-collective/borgmatic/issues/655#issuecomment-5679) helped.

This solution passes all current tests, so it should be backward compatible, and does not raise an error anymore when source dirs don't exist:
![image](https://user-images.githubusercontent.com/41837037/226800424-b818af62-098e-4ad6-ab31-c211871fa17a.png)
