### PR TITLE
feat: allow defining custom variables in config file

### DIFF
--- a/borgmatic/config/load.py
+++ b/borgmatic/config/load.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import logging
 import os
 
@@ -104,7 +105,8 @@ def load_configuration(filename):
         config = yaml.load(file_contents)
         if config and 'constants' in config:
             for key, value in config['constants'].items():
-                file_contents = file_contents.replace(f'{{{key}}}', str(value))
+                value = json.dumps(value)
+                file_contents = file_contents.replace(f'{{{key}}}', value)
             config = yaml.load(file_contents)
             del config['constants']
         return config

--- a/borgmatic/config/load.py
+++ b/borgmatic/config/load.py
@@ -100,8 +100,8 @@ def load_configuration(filename):
     yaml = ruamel.yaml.YAML(typ='safe')
     yaml.Constructor = Include_constructor_with_include_directory
 
-    with open(filename) as f:
-        file_contents = f.read()
+    with open(filename) as file:
+        file_contents = file.read()
         config = yaml.load(file_contents)
         if config and 'constants' in config:
             for key, value in config['constants'].items():

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -3,6 +3,17 @@ required:
     - location
 additionalProperties: false
 properties:
+    constants:
+        type: object
+        description: |
+            Constants to use in the configuration file. All occurences of the
+            constant name within culy braces will be replaced with the value.
+            For example, if you have a constant named "hostname" with the value
+            "myhostname", then the string "{hostname}" will be replaced with
+            "myhostname" in the configuration file.
+        example:
+            hostname: myhostname
+            prefix: myprefix
     location:
         type: object
         description: |

--- a/tests/integration/config/test_load.py
+++ b/tests/integration/config/test_load.py
@@ -30,6 +30,21 @@ def test_load_configuration_replaces_constants():
     assert module.load_configuration('config.yaml') == {'key': 'value'}
 
 
+def test_load_configuration_replaces_complex_constants():
+    builtins = flexmock(sys.modules['builtins'])
+    config_file = io.StringIO(
+        '''
+        constants:
+            key:
+                subkey: value
+        key: {key}
+        '''
+    )
+    config_file.name = 'config.yaml'
+    builtins.should_receive('open').with_args('config.yaml').and_return(config_file)
+    assert module.load_configuration('config.yaml') == {'key': {'subkey': 'value'}}
+
+
 def test_load_configuration_inlines_include_relative_to_current_directory():
     builtins = flexmock(sys.modules['builtins'])
     flexmock(module.os).should_receive('getcwd').and_return('/tmp')

--- a/tests/integration/config/test_load.py
+++ b/tests/integration/config/test_load.py
@@ -10,8 +10,23 @@ from borgmatic.config import load as module
 
 def test_load_configuration_parses_contents():
     builtins = flexmock(sys.modules['builtins'])
-    builtins.should_receive('open').with_args('config.yaml').and_return('key: value')
+    config_file = io.StringIO('key: value')
+    config_file.name = 'config.yaml'
+    builtins.should_receive('open').with_args('config.yaml').and_return(config_file)
+    assert module.load_configuration('config.yaml') == {'key': 'value'}
 
+
+def test_load_configuration_replaces_constants():
+    builtins = flexmock(sys.modules['builtins'])
+    config_file = io.StringIO(
+        '''
+        constants:
+            key: value
+        key: {key}
+        '''
+    )
+    config_file.name = 'config.yaml'
+    builtins.should_receive('open').with_args('config.yaml').and_return(config_file)
     assert module.load_configuration('config.yaml') == {'key': 'value'}
 
 


### PR DESCRIPTION
- [x]  Tests pass
- [x] can replace primitive constants
- [x] Support more [complex](https://projects.torsion.org/borgmatic-collective/borgmatic/issues/612#issuecomment-5715) data types.

Still have to add support for the third point from `generate.py::render_configuration()` and test it out.

Questions:
1. Should this support more complex cases like these:

```yaml
constants:
  x: /home/divi/folder
  y: {x}/file.txt
```
