### PR TITLE
fix: docs cli reference create spelling

### DIFF
--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -225,7 +225,7 @@ def make_parsers():
     subparsers = top_level_parser.add_subparsers(
         title='actions',
         metavar='',
-        help='Specify zero or more actions. Defaults to creat, prune, compact, and check. Use --help with action for details:',
+        help='Specify zero or more actions. Defaults to create, prune, compact, and check. Use --help with action for details:',
     )
     rcreate_parser = subparsers.add_parser(
         'rcreate',


### PR DESCRIPTION
Was checking out [#462](https://projects.torsion.org/borgmatic-collective/borgmatic/issues/462), trying to find out where the default behaviour for `borgmatic` is documented.
Found this small spelling mistake.
This should change the [docs](https://torsion.org/borgmatic/docs/reference/command-line/) too right?