### PR TITLE
Fix randomly failing test: test_log_outputs_kills_other_processes_when_one_errors

### DIFF
--- a/tests/integration/test_execute.py
+++ b/tests/integration/test_execute.py
@@ -147,7 +147,7 @@ def test_log_outputs_kills_other_processes_when_one_errors():
         ['sleep', '2'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
     flexmock(module).should_receive('exit_code_indicates_error').with_args(
-        other_process, None, 'borg'
+        ['sleep', '2'], None, 'borg'
     ).and_return(False)
     flexmock(module).should_receive('output_buffer_for_process').with_args(process, ()).and_return(
         process.stdout


### PR DESCRIPTION
This test is failing randomly with the following error:
```
E       flexmock.exceptions.MethodSignatureError: Arguments for call exit_code_indicates_error did not match expectations:
E         Received call:        exit_code_indicates_error(['sleep', '2'], None, "borg")
E         Expected call[1]:     exit_code_indicates_error(command=<Popen: returncode: None args: ['sleep', '2']>, exit_code=None, borg_local_path="borg")
E         Expected call[2]:     exit_code_indicates_error(command=['grep'], exit_code=2, borg_local_path="borg")
E         Expected call[3]:     exit_code_indicates_error(command=['grep'], exit_code=None, borg_local_path="borg")
```

The following line caused the mock to fail:

https://github.com/borgmatic-collective/borgmatic/blob/f256908b2709b643b4f7b27fd3fda150d3d32bca/borgmatic/execute.py#L138

This random failure is introduced in commit bd235f042602a9a29cc5f81880e3b36c21c0fcc3.

This PR  updates the mock code to ensure that the test won't fail randomly.