### PR TITLE
add favicon to documentation

### DIFF
--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="icon" href="docs/static/borgmatic.png" type="image/x-icon">
 		<title>{{ subtitle + ' - ' if subtitle}}{{ title }}</title>
 {%- set css %}
 {% include 'index.css' %}


### PR DESCRIPTION
I thought this was missing 😅.
A green/grey icon would be better for dark mode users, though.
![image](https://user-images.githubusercontent.com/41837037/229504726-157930a3-12f8-4f17-b624-6b82451f86ad.png)

Before:
![image](https://user-images.githubusercontent.com/41837037/229504873-d1812d06-4a96-4932-a23c-8ce0928593f7.png)

After:
![image](https://user-images.githubusercontent.com/41837037/229504836-7b530af9-fdf0-420e-a64e-6ac9812dc975.png)

(Irrelevant, but why is the title on the home page not capitalised?)
