### PR TITLE
feat: store configs used to create an archive in the archive and add borgmatic bootstrap

### DIFF
--- a/borgmatic/actions/bootstrap.py
+++ b/borgmatic/actions/bootstrap.py
@@ -70,7 +70,7 @@ def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
             local_borg_version,
             global_arguments,
             extract_to_stdout=False,
-            destination_path=bootstrap_arguments.destination,
+            destination_path=bootstrap_arguments.destination or '/',
             strip_components=bootstrap_arguments.strip_components,
             progress=bootstrap_arguments.progress,
         )

--- a/borgmatic/actions/bootstrap.py
+++ b/borgmatic/actions/bootstrap.py
@@ -1,0 +1,73 @@
+import logging
+import os
+import json
+
+import borgmatic.borg.extract
+import borgmatic.borg.rlist
+import borgmatic.config.validate
+import borgmatic.hooks.command
+
+from borgmatic.borg.state import DEFAULT_BORGMATIC_SOURCE_DIRECTORY
+
+logger = logging.getLogger(__name__)
+
+def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
+    borgmatic_source_directory = DEFAULT_BORGMATIC_SOURCE_DIRECTORY
+    borgmatic_manifest_path = os.path.expanduser(
+        os.path.join(borgmatic_source_directory, 'bootstrap', 'configs-list.json')
+    )
+    extract_process = borgmatic.borg.extract.extract_archive(
+        global_arguments.dry_run,
+        bootstrap_arguments.repository,
+        borgmatic.borg.rlist.resolve_archive_name(
+            bootstrap_arguments.repository,
+            bootstrap_arguments.archive or 'latest',
+            {},
+            local_borg_version,
+            global_arguments
+        ),
+        [borgmatic_manifest_path],
+        {},
+        {},
+        local_borg_version,
+        global_arguments,
+        extract_to_stdout=True,
+    )
+
+    manifest_data = json.loads(extract_process.stdout.read())
+
+    return manifest_data['config_paths']
+
+    
+
+
+def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
+    '''
+    Run the "bootstrap" action for the given repository.
+    '''
+    manifest_config_paths = get_config_paths(bootstrap_arguments, global_arguments, local_borg_version)
+
+    for config_path in manifest_config_paths:
+        logger.info('Bootstrapping config path %s', config_path)
+
+        borgmatic.borg.extract.extract_archive(
+            global_arguments.dry_run,
+            bootstrap_arguments.repository,
+            borgmatic.borg.rlist.resolve_archive_name(
+                bootstrap_arguments.repository,
+                bootstrap_arguments.archive or 'latest',
+                {},
+                local_borg_version,
+                global_arguments
+            ),
+            [config_path],
+            {},
+            {},
+            local_borg_version,
+            global_arguments,
+            extract_to_stdout=False,
+        )
+
+        
+
+

--- a/borgmatic/actions/bootstrap.py
+++ b/borgmatic/actions/bootstrap.py
@@ -12,7 +12,7 @@ from borgmatic.borg.state import DEFAULT_BORGMATIC_SOURCE_DIRECTORY
 logger = logging.getLogger(__name__)
 
 def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
-    borgmatic_source_directory = DEFAULT_BORGMATIC_SOURCE_DIRECTORY
+    borgmatic_source_directory = bootstrap_arguments.borgmatic_source_directory or DEFAULT_BORGMATIC_SOURCE_DIRECTORY
     borgmatic_manifest_path = os.path.expanduser(
         os.path.join(borgmatic_source_directory, 'bootstrap', 'configs-list.json')
     )
@@ -34,7 +34,11 @@ def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
         extract_to_stdout=True,
     )
 
-    manifest_data = json.loads(extract_process.stdout.read())
+    try:
+        manifest_data = json.loads(extract_process.stdout.read())
+    except json.decoder.JSONDecodeError as error:
+        logger.error('Error parsing manifest data: %s', error)
+        raise
 
     return manifest_data['config_paths']
 
@@ -66,6 +70,9 @@ def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
             local_borg_version,
             global_arguments,
             extract_to_stdout=False,
+            destination_path=bootstrap_arguments.destination,
+            strip_components=bootstrap_arguments.strip_components,
+            progress=bootstrap_arguments.progress,
         )
 
         

--- a/borgmatic/actions/config/bootstrap.py
+++ b/borgmatic/actions/config/bootstrap.py
@@ -14,14 +14,14 @@ logger = logging.getLogger(__name__)
 def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
     borgmatic_source_directory = bootstrap_arguments.borgmatic_source_directory or DEFAULT_BORGMATIC_SOURCE_DIRECTORY
     borgmatic_manifest_path = os.path.expanduser(
-        os.path.join(borgmatic_source_directory, 'bootstrap', 'configs-list.json')
+        os.path.join(borgmatic_source_directory, 'bootstrap', 'manifest.json')
     )
     extract_process = borgmatic.borg.extract.extract_archive(
         global_arguments.dry_run,
         bootstrap_arguments.repository,
         borgmatic.borg.rlist.resolve_archive_name(
             bootstrap_arguments.repository,
-            bootstrap_arguments.archive or 'latest',
+            bootstrap_arguments.archive,
             {},
             local_borg_version,
             global_arguments
@@ -34,11 +34,7 @@ def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
         extract_to_stdout=True,
     )
 
-    try:
-        manifest_data = json.loads(extract_process.stdout.read())
-    except json.decoder.JSONDecodeError as error:
-        logger.error('Error parsing manifest data: %s', error)
-        raise
+    manifest_data = json.loads(extract_process.stdout.read())
 
     return manifest_data['config_paths']
 
@@ -59,7 +55,7 @@ def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
             bootstrap_arguments.repository,
             borgmatic.borg.rlist.resolve_archive_name(
                 bootstrap_arguments.repository,
-                bootstrap_arguments.archive or 'latest',
+                bootstrap_arguments.archive,
                 {},
                 local_borg_version,
                 global_arguments
@@ -70,7 +66,7 @@ def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
             local_borg_version,
             global_arguments,
             extract_to_stdout=False,
-            destination_path=bootstrap_arguments.destination or '/',
+            destination_path=bootstrap_arguments.destination,
             strip_components=bootstrap_arguments.strip_components,
             progress=bootstrap_arguments.progress,
         )

--- a/borgmatic/actions/config/bootstrap.py
+++ b/borgmatic/actions/config/bootstrap.py
@@ -12,6 +12,16 @@ logger = logging.getLogger(__name__)
 
 
 def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
+    '''
+    Given:
+    The bootstrap arguments, which include the repository and archive name, borgmatic source directory,
+    destination directory, and whether to strip components.
+    The global arguments, which include the dry run flag
+    and the local borg version,
+    Return:
+    The config paths from the manifest.json file in the borgmatic source directory after extracting it from the
+    repository.
+    '''
     borgmatic_source_directory = (
         bootstrap_arguments.borgmatic_source_directory or DEFAULT_BORGMATIC_SOURCE_DIRECTORY
     )

--- a/borgmatic/actions/config/bootstrap.py
+++ b/borgmatic/actions/config/bootstrap.py
@@ -1,18 +1,20 @@
+import json
 import logging
 import os
-import json
 
 import borgmatic.borg.extract
 import borgmatic.borg.rlist
 import borgmatic.config.validate
 import borgmatic.hooks.command
-
 from borgmatic.borg.state import DEFAULT_BORGMATIC_SOURCE_DIRECTORY
 
 logger = logging.getLogger(__name__)
 
+
 def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
-    borgmatic_source_directory = bootstrap_arguments.borgmatic_source_directory or DEFAULT_BORGMATIC_SOURCE_DIRECTORY
+    borgmatic_source_directory = (
+        bootstrap_arguments.borgmatic_source_directory or DEFAULT_BORGMATIC_SOURCE_DIRECTORY
+    )
     borgmatic_manifest_path = os.path.expanduser(
         os.path.join(borgmatic_source_directory, 'bootstrap', 'manifest.json')
     )
@@ -24,7 +26,7 @@ def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
             bootstrap_arguments.archive,
             {},
             local_borg_version,
-            global_arguments
+            global_arguments,
         ),
         [borgmatic_manifest_path],
         {},
@@ -38,14 +40,14 @@ def get_config_paths(bootstrap_arguments, global_arguments, local_borg_version):
 
     return manifest_data['config_paths']
 
-    
-
 
 def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
     '''
     Run the "bootstrap" action for the given repository.
     '''
-    manifest_config_paths = get_config_paths(bootstrap_arguments, global_arguments, local_borg_version)
+    manifest_config_paths = get_config_paths(
+        bootstrap_arguments, global_arguments, local_borg_version
+    )
 
     for config_path in manifest_config_paths:
         logger.info('Bootstrapping config path %s', config_path)
@@ -58,7 +60,7 @@ def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
                 bootstrap_arguments.archive,
                 {},
                 local_borg_version,
-                global_arguments
+                global_arguments,
             ),
             [config_path],
             {},
@@ -70,7 +72,3 @@ def run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version):
             strip_components=bootstrap_arguments.strip_components,
             progress=bootstrap_arguments.progress,
         )
-
-        
-
-

--- a/borgmatic/actions/create.py
+++ b/borgmatic/actions/create.py
@@ -1,15 +1,17 @@
 import json
-import os
 import logging
+import os
 
-import importlib_metadata
+try:
+    import importlib_metadata
+except ModuleNotFoundError:  # pragma: nocover
+    import importlib.metadata as importlib_metadata
 
 import borgmatic.borg.create
 import borgmatic.config.validate
 import borgmatic.hooks.command
 import borgmatic.hooks.dispatch
 import borgmatic.hooks.dump
-
 from borgmatic.borg.state import DEFAULT_BORGMATIC_SOURCE_DIRECTORY
 
 logger = logging.getLogger(__name__)
@@ -23,10 +25,8 @@ def create_borgmatic_manifest(location, config_paths, dry_run):
     if dry_run:
         return
 
-    borgmatic_source_directory = (
-        location.get('borgmatic_source_directory')
-        if location.get('borgmatic_source_directory')
-        else DEFAULT_BORGMATIC_SOURCE_DIRECTORY
+    borgmatic_source_directory = location.get(
+        'borgmatic_source_directory', DEFAULT_BORGMATIC_SOURCE_DIRECTORY
     )
 
     borgmatic_manifest_path = os.path.expanduser(
@@ -36,13 +36,13 @@ def create_borgmatic_manifest(location, config_paths, dry_run):
     if not os.path.exists(borgmatic_manifest_path):
         os.makedirs(os.path.dirname(borgmatic_manifest_path), exist_ok=True)
 
-    with open(borgmatic_manifest_path, 'w') as f:
+    with open(borgmatic_manifest_path, 'w') as config_list_file:
         json.dump(
             {
                 'borgmatic_version': importlib_metadata.version('borgmatic'),
                 'config_paths': config_paths,
             },
-            f,
+            config_list_file,
         )
 
 

--- a/borgmatic/actions/create.py
+++ b/borgmatic/actions/create.py
@@ -30,7 +30,7 @@ def create_borgmatic_manifest(location, config_paths, dry_run):
     )
 
     borgmatic_manifest_path = os.path.expanduser(
-        os.path.join(borgmatic_source_directory, 'bootstrap', 'configs-list.json')
+        os.path.join(borgmatic_source_directory, 'bootstrap', 'manifest.json')
     )
 
     if not os.path.exists(borgmatic_manifest_path):

--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -351,7 +351,9 @@ def create_archive(
     sources = deduplicate_directories(
         map_directories_to_devices(
             expand_directories(
-                tuple(location_config.get('source_directories', ())) + borgmatic_source_directories + tuple(global_arguments.config_paths)
+                tuple(location_config.get('source_directories', ()))
+                + borgmatic_source_directories
+                + tuple(global_arguments.used_config_paths)
             )
         ),
         additional_directory_devices=map_directories_to_devices(

--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -351,7 +351,7 @@ def create_archive(
     sources = deduplicate_directories(
         map_directories_to_devices(
             expand_directories(
-                tuple(location_config.get('source_directories', ())) + borgmatic_source_directories
+                tuple(location_config.get('source_directories', ())) + borgmatic_source_directories + tuple(global_arguments.config_paths)
             )
         ),
         additional_directory_devices=map_directories_to_devices(

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -9,6 +9,8 @@ SUBPARSER_ALIASES = {
     'compact': [],
     'create': ['-C'],
     'check': ['-k'],
+    'config': [],
+    'config_bootstrap': [],
     'extract': ['-x'],
     'export-tar': [],
     'mount': ['-m'],
@@ -521,6 +523,66 @@ def make_parsers():
     )
     extract_group.add_argument(
         '-h', '--help', action='help', help='Show this help message and exit'
+    )
+
+    config_parser = subparsers.add_parser(
+        'config',
+        aliases=SUBPARSER_ALIASES['config'],
+        help='Perform configuration file related operations',
+        description='Perform configuration file related operations',
+        add_help=False,
+        parents=[top_level_parser],
+    )
+
+    config_subparsers = config_parser.add_subparsers(
+        title='config subcommands',
+        description='Valid subcommands for config',
+        help='Additional help',
+    )
+
+    config_bootstrap_parser = config_subparsers.add_parser(
+        'bootstrap',
+        aliases=SUBPARSER_ALIASES['config_bootstrap'],
+        help='Extract files from a borgmatic created repository to the current directory',
+        description='Extract a named archive from a borgmatic created repository to the current directory without a configuration file',
+        add_help=False,
+        parents=[config_parser],
+    )
+    config_bootstrap_group = config_bootstrap_parser.add_argument_group('config bootstrap arguments')
+    config_bootstrap_group.add_argument(
+        '--repository',
+        help='Path of repository to extract',
+        required=True,
+    )
+    config_bootstrap_group.add_argument(
+        '--archive', help='Name of archive to extract, defaults to "latest"'
+    )
+    config_bootstrap_group.add_argument(
+        '--path',
+        '--restore-path',
+        metavar='PATH',
+        nargs='+',
+        dest='paths',
+        help='Paths to extract from archive, defaults to the entire archive',
+    )
+    config_bootstrap_group.add_argument(
+        '--destination',
+        metavar='PATH',
+        dest='destination',
+        help='Directory to extract files into, defaults to the current directory',
+    )
+    config_bootstrap_group.add_argument(
+        '--strip-components',
+        type=lambda number: number if number == 'all' else int(number),
+        metavar='NUMBER',
+        help='Number of leading path components to remove from each extracted path or "all" to strip all leading path components. Skip paths with fewer elements',
+    )
+    config_bootstrap_group.add_argument(
+        '--progress',
+        dest='progress',
+        default=False,
+        action='store_true',
+        help='Display progress for each file as it is extracted',
     )
 
     export_tar_parser = subparsers.add_parser(

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -74,15 +74,15 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
                     if item in subparsers:
                         remaining_arguments.remove(item)
 
-    arguments[canonical_name] = None if canonical_name in subcommand_parsers_mapping else parsed
-
+    try:
+        arguments[canonical_name] = None if canonical_name in subcommand_parsers_mapping else parsed
+    except UnboundLocalError:
+        pass
+    
     for argument in arguments:
         if not arguments[argument]:
             if not any(subcommand in arguments for subcommand in subcommand_parsers_mapping[argument]):
-                raise ValueError("Missing subcommand for {}. Expected one of {}".format(
-                    argument, subcommand_parsers_mapping[argument]
-                ))
-            
+                raise ValueError(f"Missing subcommand for {argument}. Expected one of {subcommand_parsers_mapping[argument]}")
 
     # If no actions are explicitly requested, assume defaults.
     if not arguments and '--help' not in unparsed_arguments and '-h' not in unparsed_arguments:
@@ -564,28 +564,29 @@ def make_parsers():
     config_bootstrap_parser = config_subparsers.add_parser(
         'bootstrap',
         aliases=SUBPARSER_ALIASES['config_bootstrap'],
-        help='Extract files from a borgmatic created repository to the current directory',
-        description='Extract a named archive from a borgmatic created repository to the current directory without a configuration file',
+        help='Extract the config files used to create a borgmatic repository',
+        description='Extract just the config files that were used to create a borgmatic repository during the "create" operation',
         add_help=False,
     )
     config_bootstrap_group = config_bootstrap_parser.add_argument_group('config bootstrap arguments')
     config_bootstrap_group.add_argument(
         '--repository',
-        help='Path of repository to extract',
+        help='Path of repository to extract config files from',
         required=True,
     )
     config_bootstrap_group.add_argument(
         '--borgmatic-source-directory',
-        help='Path of the borgmatic source directory if other than the default',
+        help='Path that stores the config files used to create an archive, and additional source files used for temporary internal state like borgmatic database dumps. Defaults to ~/.borgmatic',
     )
     config_bootstrap_group.add_argument(
-        '--archive', help='Name of archive to extract, defaults to "latest"'
+        '--archive', help='Name of archive to extract config files from, defaults to "latest"', default='latest'
     )
     config_bootstrap_group.add_argument(
         '--destination',
         metavar='PATH',
         dest='destination',
-        help='Directory to extract files into, defaults to /',
+        help='Directory to extract config files into, defaults to /',
+        default='/',
     )
     config_bootstrap_group.add_argument(
         '--strip-components',

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -75,12 +75,7 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
                     if item in subparsers:
                         remaining_arguments.remove(item)
 
-        try:
-            arguments[canonical_name] = (
-                None if canonical_name in subcommand_parsers_mapping else parsed
-            )
-        except UnboundLocalError:
-            pass
+        arguments[canonical_name] = None if canonical_name in subcommand_parsers_mapping else parsed
 
     for argument in arguments:
         if not arguments[argument]:
@@ -153,7 +148,7 @@ class Extend_action(Action):
         items = getattr(namespace, self.dest, None)
 
         if items:
-            items.extend(values)
+            items.extend(values)  # pragma: no cover
         else:
             setattr(namespace, self.dest, list(values))
 

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -29,7 +29,9 @@ SUBPARSER_ALIASES = {
 
 
 def get_unparsable_arguments(remaining_subparser_arguments):
-    # Determine the remaining arguments that no subparsers have consumed.
+    '''
+    Determine the remaining arguments that no subparsers have consumed.
+    '''
     if remaining_subparser_arguments:
         remaining_arguments = [
             argument
@@ -590,7 +592,7 @@ def make_parsers():
         'bootstrap',
         aliases=SUBPARSER_ALIASES['config_bootstrap'],
         help='Extract the config files used to create a borgmatic repository',
-        description='Extract just the config files that were used to create a borgmatic repository during the "create" operation',
+        description='Extract config files that were used to create a borgmatic repository during the "create" operation',
         add_help=False,
     )
     config_bootstrap_group = config_bootstrap_parser.add_argument_group(
@@ -603,7 +605,7 @@ def make_parsers():
     )
     config_bootstrap_group.add_argument(
         '--borgmatic-source-directory',
-        help='Path that stores the config files used to create an archive, and additional source files used for temporary internal state like borgmatic database dumps. Defaults to ~/.borgmatic',
+        help='Path that stores the config files used to create an archive and additional source files used for temporary internal state like borgmatic database dumps. Defaults to ~/.borgmatic',
     )
     config_bootstrap_group.add_argument(
         '--archive',
@@ -980,13 +982,24 @@ def make_parsers():
         None, None, metavar=None, dest='merged', parser_class=None
     )
 
-    for name, subparser in subparsers.choices.items():
-        merged_subparsers._name_parser_map[name] = subparser
-
-    for name, subparser in config_subparsers.choices.items():
-        merged_subparsers._name_parser_map[name] = subparser
+    merged_subparsers = merge_subparsers(subparsers, config_subparsers)
 
     return top_level_parser, merged_subparsers
+
+
+def merge_subparsers(*subparsers):
+    '''
+    Merge multiple subparsers into a single subparser.
+    '''
+    merged_subparsers = argparse._SubParsersAction(
+        None, None, metavar=None, dest='merged', parser_class=None
+    )
+
+    for subparser in subparsers:
+        for name, subparser in subparser.choices.items():
+            merged_subparsers._name_parser_map[name] = subparser
+
+    return merged_subparsers
 
 
 def parse_arguments(*unparsed_arguments):

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -48,7 +48,7 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
     if 'borg' in unparsed_arguments:
         subparsers = {'borg': subparsers['borg']}
 
-    for argument in remaining_arguments:
+    for argument in reversed(remaining_arguments):
         canonical_name = alias_to_subparser_name.get(argument, argument)
         subparser = subparsers.get(canonical_name)
 
@@ -531,7 +531,11 @@ def make_parsers():
         help='Perform configuration file related operations',
         description='Perform configuration file related operations',
         add_help=False,
-        parents=[top_level_parser],
+    )
+
+    config_group = config_parser.add_argument_group('config arguments')
+    config_group.add_argument(
+        '-h', '--help', action='help', help='Show this help message and exit'
     )
 
     config_subparsers = config_parser.add_subparsers(
@@ -546,7 +550,6 @@ def make_parsers():
         help='Extract files from a borgmatic created repository to the current directory',
         description='Extract a named archive from a borgmatic created repository to the current directory without a configuration file',
         add_help=False,
-        parents=[config_parser],
     )
     config_bootstrap_group = config_bootstrap_parser.add_argument_group('config bootstrap arguments')
     config_bootstrap_group.add_argument(
@@ -583,6 +586,9 @@ def make_parsers():
         default=False,
         action='store_true',
         help='Display progress for each file as it is extracted',
+    )
+    config_bootstrap_group.add_argument(
+        '-h', '--help', action='help', help='Show this help message and exit'
     )
 
     export_tar_parser = subparsers.add_parser(

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -99,8 +99,6 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
     # allows subparsers to consume arguments before their parent subparsers do.
     remaining_subparser_arguments = []
 
-    # Now ask each subparser, one by one, to greedily consume arguments, from last to first. This
-    # allows subparsers to consume arguments before their parent subparsers do.
     for subparser_name, subparser in reversed(subparsers.items()):
         if subparser_name not in arguments.keys():
             continue

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -74,10 +74,10 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
                     if item in subparsers:
                         remaining_arguments.remove(item)
 
-    try:
-        arguments[canonical_name] = None if canonical_name in subcommand_parsers_mapping else parsed
-    except UnboundLocalError:
-        pass
+        try:
+            arguments[canonical_name] = None if canonical_name in subcommand_parsers_mapping else parsed
+        except UnboundLocalError:
+            pass
     
     for argument in arguments:
         if not arguments[argument]:
@@ -972,7 +972,7 @@ def parse_arguments(*unparsed_arguments):
         unparsed_arguments, subparsers.choices
     )
 
-    if 'bootstrap' in arguments.keys() and len(arguments.keys()) > 1:
+    if 'bootstrap' in arguments.keys() and 'config' in arguments.keys() and len(arguments.keys()) > 2:
         raise ValueError(
             'The bootstrap action cannot be combined with other actions. Please run it separately.'
         )

--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -577,21 +577,17 @@ def make_parsers():
         required=True,
     )
     config_bootstrap_group.add_argument(
-        '--archive', help='Name of archive to extract, defaults to "latest"'
+        '--borgmatic-source-directory',
+        help='Path of the borgmatic source directory if other than the default',
     )
     config_bootstrap_group.add_argument(
-        '--path',
-        '--restore-path',
-        metavar='PATH',
-        nargs='+',
-        dest='paths',
-        help='Paths to extract from archive, defaults to the entire archive',
+        '--archive', help='Name of archive to extract, defaults to "latest"'
     )
     config_bootstrap_group.add_argument(
         '--destination',
         metavar='PATH',
         dest='destination',
-        help='Directory to extract files into, defaults to the current directory',
+        help='Directory to extract files into, defaults to /',
     )
     config_bootstrap_group.add_argument(
         '--strip-components',

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -643,7 +643,7 @@ def collect_configuration_run_summary_logs(configs, arguments):
             OSError,
             json.JSONDecodeError,
             KeyError,
-        ) as error:  # pragma: no cover
+        ) as error:
             yield from log_error_records('Error running bootstrap', error)
         return
 

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -18,10 +18,10 @@ import borgmatic.actions.borg
 import borgmatic.actions.break_lock
 import borgmatic.actions.check
 import borgmatic.actions.compact
+import borgmatic.actions.config.bootstrap
 import borgmatic.actions.create
 import borgmatic.actions.export_tar
 import borgmatic.actions.extract
-import borgmatic.actions.config.bootstrap
 import borgmatic.actions.info
 import borgmatic.actions.list
 import borgmatic.actions.mount
@@ -622,12 +622,14 @@ def collect_configuration_run_summary_logs(configs, arguments):
     except ValueError as error:
         yield from log_error_records(str(error))
         return
-    
+
     if 'bootstrap' in arguments:
         # no configuration file is needed for bootstrap
         local_borg_version = borg_version.local_borg_version({}, 'borg')
         try:
-            borgmatic.actions.config.bootstrap.run_bootstrap(arguments['bootstrap'], arguments['global'], local_borg_version)
+            borgmatic.actions.config.bootstrap.run_bootstrap(
+                arguments['bootstrap'], arguments['global'], local_borg_version
+            )
             yield logging.makeLogRecord(
                 dict(
                     levelno=logging.INFO,

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -616,7 +616,8 @@ def collect_configuration_run_summary_logs(configs, arguments):
         if 'extract' in arguments or 'mount' in arguments:
             validate.guard_single_repository_selected(repository, configs)
 
-        validate.guard_configuration_contains_repository(repository, configs)
+        if 'config' not in arguments:
+            validate.guard_configuration_contains_repository(repository, configs)
     except ValueError as error:
         yield from log_error_records(str(error))
         return

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -21,7 +21,7 @@ import borgmatic.actions.compact
 import borgmatic.actions.create
 import borgmatic.actions.export_tar
 import borgmatic.actions.extract
-import borgmatic.actions.bootstrap
+import borgmatic.actions.config.bootstrap
 import borgmatic.actions.info
 import borgmatic.actions.list
 import borgmatic.actions.mount
@@ -627,7 +627,7 @@ def collect_configuration_run_summary_logs(configs, arguments):
         # no configuration file is needed for bootstrap
         local_borg_version = borg_version.local_borg_version({}, 'borg')
         try:
-            borgmatic.actions.bootstrap.run_bootstrap(arguments['bootstrap'], arguments['global'], local_borg_version)
+            borgmatic.actions.config.bootstrap.run_bootstrap(arguments['bootstrap'], arguments['global'], local_borg_version)
             yield logging.makeLogRecord(
                 dict(
                     levelno=logging.INFO,
@@ -635,7 +635,7 @@ def collect_configuration_run_summary_logs(configs, arguments):
                     msg='Bootstrap successful',
                 )
             )
-        except (CalledProcessError, ValueError, OSError) as error:
+        except (CalledProcessError, ValueError, OSError, json.JSONDecodeError, KeyError) as error:
             yield from log_error_records('Error running bootstrap', error)
         return
 

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -645,6 +645,7 @@ def collect_configuration_run_summary_logs(configs, arguments):
             KeyError,
         ) as error:
             yield from log_error_records('Error running bootstrap', error)
+
         return
 
     if not configs:

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -637,7 +637,13 @@ def collect_configuration_run_summary_logs(configs, arguments):
                     msg='Bootstrap successful',
                 )
             )
-        except (CalledProcessError, ValueError, OSError, json.JSONDecodeError, KeyError) as error:
+        except (
+            CalledProcessError,
+            ValueError,
+            OSError,
+            json.JSONDecodeError,
+            KeyError,
+        ) as error:  # pragma: no cover
             yield from log_error_records('Error running bootstrap', error)
         return
 

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -21,6 +21,7 @@ import borgmatic.actions.compact
 import borgmatic.actions.create
 import borgmatic.actions.export_tar
 import borgmatic.actions.extract
+import borgmatic.actions.bootstrap
 import borgmatic.actions.info
 import borgmatic.actions.list
 import borgmatic.actions.mount
@@ -620,6 +621,19 @@ def collect_configuration_run_summary_logs(configs, arguments):
             validate.guard_configuration_contains_repository(repository, configs)
     except ValueError as error:
         yield from log_error_records(str(error))
+        return
+    
+    if 'bootstrap' in arguments:
+        # no configuration file is needed for bootstrap
+        local_borg_version = borg_version.local_borg_version({}, 'borg')
+        borgmatic.actions.bootstrap.run_bootstrap(arguments['bootstrap'], arguments['global'], local_borg_version)
+        yield logging.makeLogRecord(
+            dict(
+                levelno=logging.INFO,
+                levelname='INFO',
+                msg='Bootstrap successful',
+            )
+        )
         return
 
     if not configs:

--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -45,10 +45,10 @@ logger = logging.getLogger(__name__)
 LEGACY_CONFIG_PATH = '/etc/borgmatic/config'
 
 
-def run_configuration(config_filename, config, arguments):
+def run_configuration(config_filename, config, arguments, used_config_paths):
     '''
-    Given a config filename, the corresponding parsed config dict, and command-line arguments as a
-    dict from subparser name to a namespace of parsed arguments, execute the defined create, prune,
+    Given a config filename, the corresponding parsed config dict, command-line arguments as a
+    dict from subparser name to a namespace of parsed arguments, and a list of paths of all configs used, execute the defined create, prune,
     compact, check, and/or other actions.
 
     Yield a combination of:
@@ -61,6 +61,7 @@ def run_configuration(config_filename, config, arguments):
         for section_name in ('location', 'storage', 'retention', 'consistency', 'hooks')
     )
     global_arguments = arguments['global']
+    global_arguments.config_paths = used_config_paths
 
     local_path = location.get('local_path', 'borg')
     remote_path = location.get('remote_path')
@@ -644,8 +645,9 @@ def collect_configuration_run_summary_logs(configs, arguments):
 
     # Execute the actions corresponding to each configuration file.
     json_results = []
+    used_config_paths = list(configs.keys())
     for config_filename, config in configs.items():
-        results = list(run_configuration(config_filename, config, arguments))
+        results = list(run_configuration(config_filename, config, arguments, used_config_paths))
         error_logs = tuple(result for result in results if isinstance(result, logging.LogRecord))
 
         if error_logs:

--- a/tests/integration/commands/test_arguments.py
+++ b/tests/integration/commands/test_arguments.py
@@ -297,6 +297,12 @@ def test_parse_arguments_disallows_paths_unless_action_consumes_it():
     with pytest.raises(SystemExit):
         module.parse_arguments('--config', 'myconfig', '--path', 'test')
 
+def test_parse_arguments_disallows_other_actions_with_config_bootstrap():
+    flexmock(module.collect).should_receive('get_default_config_paths').and_return(['default'])
+
+    with pytest.raises(ValueError):
+        module.parse_arguments('config', 'bootstrap', '--repository', 'test.borg', 'list')
+
 
 def test_parse_arguments_allows_archive_with_extract():
     flexmock(module.collect).should_receive('get_default_config_paths').and_return(['default'])

--- a/tests/integration/commands/test_arguments.py
+++ b/tests/integration/commands/test_arguments.py
@@ -1,3 +1,5 @@
+import argparse
+
 import pytest
 from flexmock import flexmock
 
@@ -530,3 +532,33 @@ def test_parse_arguments_extract_with_check_only_extract_does_not_raise():
     flexmock(module.collect).should_receive('get_default_config_paths').and_return(['default'])
 
     module.parse_arguments('extract', '--archive', 'name', 'check', '--only', 'extract')
+
+
+def test_merging_two_subparser_collections_merges_their_choices():
+    top_level_parser = argparse.ArgumentParser()
+
+    subparsers = top_level_parser.add_subparsers()
+
+    subparser1 = subparsers.add_parser('subparser1')
+
+    subparser2 = subparsers.add_parser('subparser2')
+
+    subsubparsers = subparser2.add_subparsers()
+
+    subsubparser1 = subsubparsers.add_parser('subsubparser1')
+
+    merged_subparsers = argparse._SubParsersAction(
+        None, None, metavar=None, dest='merged', parser_class=None
+    )
+
+    for name, subparser in subparsers.choices.items():
+        merged_subparsers._name_parser_map[name] = subparser
+
+    for name, subparser in subsubparsers.choices.items():
+        merged_subparsers._name_parser_map[name] = subparser
+
+    assert merged_subparsers.choices == {
+        'subparser1': subparser1,
+        'subparser2': subparser2,
+        'subsubparser1': subsubparser1,
+    }

--- a/tests/integration/commands/test_arguments.py
+++ b/tests/integration/commands/test_arguments.py
@@ -538,24 +538,17 @@ def test_merging_two_subparser_collections_merges_their_choices():
     top_level_parser = argparse.ArgumentParser()
 
     subparsers = top_level_parser.add_subparsers()
-
     subparser1 = subparsers.add_parser('subparser1')
 
     subparser2 = subparsers.add_parser('subparser2')
-
     subsubparsers = subparser2.add_subparsers()
-
     subsubparser1 = subsubparsers.add_parser('subsubparser1')
 
     merged_subparsers = argparse._SubParsersAction(
         None, None, metavar=None, dest='merged', parser_class=None
     )
 
-    for name, subparser in subparsers.choices.items():
-        merged_subparsers._name_parser_map[name] = subparser
-
-    for name, subparser in subsubparsers.choices.items():
-        merged_subparsers._name_parser_map[name] = subparser
+    merged_subparsers = module.merge_subparsers(subparsers, subsubparsers)
 
     assert merged_subparsers.choices == {
         'subparser1': subparser1,

--- a/tests/integration/commands/test_arguments.py
+++ b/tests/integration/commands/test_arguments.py
@@ -297,6 +297,7 @@ def test_parse_arguments_disallows_paths_unless_action_consumes_it():
     with pytest.raises(SystemExit):
         module.parse_arguments('--config', 'myconfig', '--path', 'test')
 
+
 def test_parse_arguments_disallows_other_actions_with_config_bootstrap():
     flexmock(module.collect).should_receive('get_default_config_paths').and_return(['default'])
 

--- a/tests/unit/actions/config/test_bootstrap.py
+++ b/tests/unit/actions/config/test_bootstrap.py
@@ -1,0 +1,33 @@
+from flexmock import flexmock
+
+from borgmatic.actions.config import bootstrap as module
+
+
+def test_run_bootstrap():
+    bootstrap_arguments = flexmock(
+        repository='repo',
+        archive='archive',
+        destination='dest',
+        strip_components=1,
+        progress=False,
+        borgmatic_source_directory='/borgmatic',
+    )
+    global_arguments = flexmock(
+        dry_run=False,
+    )
+    local_borg_version = flexmock()
+    extract_process = flexmock(
+        stdout=flexmock(
+            read=lambda: '{"config_paths": ["/borgmatic/config.yaml"]}',
+        ),
+    )
+    flexmock(module.borgmatic.borg.extract).should_receive('extract_archive').and_return(
+        extract_process
+    )
+    flexmock(module.borgmatic.borg.rlist).should_receive('resolve_archive_name').and_return(
+        'archive'
+    )
+    flexmock(module.borgmatic.borg.extract).should_receive('extract_archive').and_return(
+        extract_process
+    )
+    module.run_bootstrap(bootstrap_arguments, global_arguments, local_borg_version)

--- a/tests/unit/actions/config/test_bootstrap.py
+++ b/tests/unit/actions/config/test_bootstrap.py
@@ -24,9 +24,9 @@ def test_get_config_paths_returns_list_of_config_paths():
     flexmock(module.borgmatic.borg.rlist).should_receive('resolve_archive_name').and_return(
         'archive'
     )
-    assert module.get_config_paths(
-        bootstrap_arguments, global_arguments, local_borg_version
-    ) == ['/borgmatic/config.yaml']
+    assert module.get_config_paths(bootstrap_arguments, global_arguments, local_borg_version) == [
+        '/borgmatic/config.yaml'
+    ]
 
 
 def test_run_bootstrap_does_not_raise():

--- a/tests/unit/actions/test_create.py
+++ b/tests/unit/actions/test_create.py
@@ -1,3 +1,4 @@
+import sys
 from flexmock import flexmock
 
 from borgmatic.actions import create as module
@@ -7,6 +8,7 @@ def test_run_create_executes_and_calls_hooks_for_configured_repository():
     flexmock(module.logger).answer = lambda message: None
     flexmock(module.borgmatic.config.validate).should_receive('repositories_match').never()
     flexmock(module.borgmatic.borg.create).should_receive('create_archive').once()
+    flexmock(module).should_receive('create_borgmatic_manifest').once()
     flexmock(module.borgmatic.hooks.command).should_receive('execute_hook').times(2)
     flexmock(module.borgmatic.hooks.dispatch).should_receive('call_hooks').and_return({})
     flexmock(module.borgmatic.hooks.dispatch).should_receive(
@@ -45,6 +47,7 @@ def test_run_create_runs_with_selected_repository():
         'repositories_match'
     ).once().and_return(True)
     flexmock(module.borgmatic.borg.create).should_receive('create_archive').once()
+    flexmock(module).should_receive('create_borgmatic_manifest').once()
     create_arguments = flexmock(
         repository=flexmock(),
         progress=flexmock(),
@@ -78,6 +81,7 @@ def test_run_create_bails_if_repository_does_not_match():
         'repositories_match'
     ).once().and_return(False)
     flexmock(module.borgmatic.borg.create).should_receive('create_archive').never()
+    flexmock(module).should_receive('create_borgmatic_manifest').never()
     create_arguments = flexmock(
         repository=flexmock(),
         progress=flexmock(),
@@ -106,14 +110,38 @@ def test_run_create_bails_if_repository_does_not_match():
 
 
 def test_create_borgmatic_manifest_creates_manifest_file():
-    flexmock(module.os.path).should_receive('expanduser').and_return('/home/user')
-    flexmock(module.os.path).should_receive('join').and_return('/home/user/bootstrap/manifest.json')
     flexmock(module.os.path).should_receive('exists').and_return(False)
     flexmock(module.os).should_receive('makedirs').and_return(True)
 
+    flexmock(module.importlib_metadata).should_receive('version').and_return('1.0.0')
     flexmock(module.json).should_receive('dump').and_return(True)
 
     module.create_borgmatic_manifest({}, 'test.yaml', False)
+
+
+def test_create_borgmatic_manifest_creates_manifest_file_with_custom_borgmatic_source_directory():
+    flexmock(module.os.path).should_receive('join').with_args(
+        '/borgmatic', 'bootstrap', 'manifest.json'
+    ).and_return('/borgmatic/bootstrap/manifest.json')
+    flexmock(module.os.path).should_receive('exists').and_return(False)
+    flexmock(module.os).should_receive('makedirs').and_return(True)
+
+    flexmock(module.importlib_metadata).should_receive('version').and_return('1.0.0')
+    flexmock(sys.modules['builtins']).should_receive('open').with_args(
+        '/borgmatic/bootstrap/manifest.json', 'w'
+    ).and_return(
+        flexmock(
+            __enter__=lambda *args: flexmock(
+                write=lambda *args: None, close=lambda *args: None
+            ),
+            __exit__=lambda *args: None,
+        )
+    )
+    flexmock(module.json).should_receive('dump').and_return(True)
+
+    module.create_borgmatic_manifest(
+        {'borgmatic_source_directory': '/borgmatic'}, 'test.yaml', False
+    )
 
 
 def test_create_borgmatic_manifest_does_not_create_manifest_file_on_dry_run():

--- a/tests/unit/actions/test_create.py
+++ b/tests/unit/actions/test_create.py
@@ -103,3 +103,20 @@ def test_run_create_bails_if_repository_does_not_match():
             remote_path=None,
         )
     )
+
+
+def test_create_borgmatic_manifest_creates_manifest_file():
+    flexmock(module.os.path).should_receive('expanduser').and_return('/home/user')
+    flexmock(module.os.path).should_receive('join').and_return('/home/user/bootstrap/manifest.json')
+    flexmock(module.os.path).should_receive('exists').and_return(False)
+    flexmock(module.os).should_receive('makedirs').and_return(True)
+
+    flexmock(module.json).should_receive('dump').and_return(True)
+
+    module.create_borgmatic_manifest({}, 'test.yaml', False)
+
+
+def test_create_borgmatic_manifest_does_not_create_manifest_file_on_dry_run():
+    flexmock(module.os.path).should_receive('expanduser').never()
+
+    module.create_borgmatic_manifest({}, 'test.yaml', True)

--- a/tests/unit/actions/test_create.py
+++ b/tests/unit/actions/test_create.py
@@ -1,4 +1,5 @@
 import sys
+
 from flexmock import flexmock
 
 from borgmatic.actions import create as module
@@ -131,9 +132,7 @@ def test_create_borgmatic_manifest_creates_manifest_file_with_custom_borgmatic_s
         '/borgmatic/bootstrap/manifest.json', 'w'
     ).and_return(
         flexmock(
-            __enter__=lambda *args: flexmock(
-                write=lambda *args: None, close=lambda *args: None
-            ),
+            __enter__=lambda *args: flexmock(write=lambda *args: None, close=lambda *args: None),
             __exit__=lambda *args: None,
         )
     )

--- a/tests/unit/actions/test_create.py
+++ b/tests/unit/actions/test_create.py
@@ -19,7 +19,7 @@ def test_run_create_executes_and_calls_hooks_for_configured_repository():
         json=flexmock(),
         list_files=flexmock(),
     )
-    global_arguments = flexmock(monitoring_verbosity=1, dry_run=False)
+    global_arguments = flexmock(monitoring_verbosity=1, dry_run=False, used_config_paths=[])
 
     list(
         module.run_create(
@@ -52,7 +52,7 @@ def test_run_create_runs_with_selected_repository():
         json=flexmock(),
         list_files=flexmock(),
     )
-    global_arguments = flexmock(monitoring_verbosity=1, dry_run=False)
+    global_arguments = flexmock(monitoring_verbosity=1, dry_run=False, used_config_paths=[])
 
     list(
         module.run_create(
@@ -85,7 +85,7 @@ def test_run_create_bails_if_repository_does_not_match():
         json=flexmock(),
         list_files=flexmock(),
     )
-    global_arguments = flexmock(monitoring_verbosity=1, dry_run=False)
+    global_arguments = flexmock(monitoring_verbosity=1, dry_run=False, used_config_paths=[])
 
     list(
         module.run_create(

--- a/tests/unit/borg/test_create.py
+++ b/tests/unit/borg/test_create.py
@@ -492,7 +492,7 @@ def test_create_archive_calls_borg_with_parameters():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -536,7 +536,7 @@ def test_create_archive_calls_borg_with_environment():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -582,7 +582,7 @@ def test_create_archive_with_patterns_calls_borg_with_patterns_including_convert
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -628,7 +628,7 @@ def test_create_archive_with_exclude_patterns_calls_borg_with_excludes():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -672,7 +672,7 @@ def test_create_archive_with_log_info_calls_borg_with_info_parameter():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -713,7 +713,7 @@ def test_create_archive_with_log_info_and_json_suppresses_most_borg_output():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         json=True,
     )
 
@@ -758,7 +758,7 @@ def test_create_archive_with_log_debug_calls_borg_with_debug_parameter():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -799,7 +799,7 @@ def test_create_archive_with_log_debug_and_json_suppresses_most_borg_output():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         json=True,
     )
 
@@ -843,7 +843,7 @@ def test_create_archive_with_dry_run_calls_borg_with_dry_run_parameter():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -889,7 +889,7 @@ def test_create_archive_with_stats_and_dry_run_calls_borg_without_stats_paramete
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         stats=True,
     )
 
@@ -933,7 +933,7 @@ def test_create_archive_with_checkpoint_interval_calls_borg_with_checkpoint_inte
         },
         storage_config={'checkpoint_interval': 600},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -976,7 +976,7 @@ def test_create_archive_with_checkpoint_volume_calls_borg_with_checkpoint_volume
         },
         storage_config={'checkpoint_volume': 1024},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1019,7 +1019,7 @@ def test_create_archive_with_chunker_params_calls_borg_with_chunker_params_param
         },
         storage_config={'chunker_params': '1,2,3,4'},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1062,7 +1062,7 @@ def test_create_archive_with_compression_calls_borg_with_compression_parameters(
         },
         storage_config={'compression': 'rle'},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1111,7 +1111,7 @@ def test_create_archive_with_upload_rate_limit_calls_borg_with_upload_ratelimit_
         },
         storage_config={'upload_rate_limit': 100},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1157,7 +1157,7 @@ def test_create_archive_with_working_directory_calls_borg_with_working_directory
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1201,7 +1201,7 @@ def test_create_archive_with_one_file_system_calls_borg_with_one_file_system_par
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1251,7 +1251,7 @@ def test_create_archive_with_numeric_ids_calls_borg_with_numeric_ids_parameter(
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1305,7 +1305,7 @@ def test_create_archive_with_read_special_calls_borg_with_read_special_parameter
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1361,7 +1361,7 @@ def test_create_archive_with_basic_option_calls_borg_with_corresponding_paramete
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1416,7 +1416,7 @@ def test_create_archive_with_atime_option_calls_borg_with_corresponding_paramete
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1471,7 +1471,7 @@ def test_create_archive_with_flags_option_calls_borg_with_corresponding_paramete
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1515,7 +1515,7 @@ def test_create_archive_with_files_cache_calls_borg_with_files_cache_parameters(
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1558,7 +1558,7 @@ def test_create_archive_with_local_path_calls_borg_via_local_path():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         local_path='borg1',
     )
 
@@ -1602,7 +1602,7 @@ def test_create_archive_with_remote_path_calls_borg_with_remote_path_parameters(
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         remote_path='borg1',
     )
 
@@ -1646,7 +1646,7 @@ def test_create_archive_with_umask_calls_borg_with_umask_parameters():
         },
         storage_config={'umask': 740},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1689,7 +1689,7 @@ def test_create_archive_with_log_json_calls_borg_with_log_json_parameters():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=True),
+        global_arguments=flexmock(log_json=True, used_config_paths=[]),
     )
 
 
@@ -1732,7 +1732,7 @@ def test_create_archive_with_lock_wait_calls_borg_with_lock_wait_parameters():
         },
         storage_config={'lock_wait': 5},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -1775,7 +1775,7 @@ def test_create_archive_with_stats_calls_borg_with_stats_parameter_and_answer_ou
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         stats=True,
     )
 
@@ -1819,7 +1819,7 @@ def test_create_archive_with_files_calls_borg_with_list_parameter_and_answer_out
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         list_files=True,
     )
 
@@ -1869,7 +1869,7 @@ def test_create_archive_with_progress_and_log_info_calls_borg_with_progress_para
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         progress=True,
     )
 
@@ -1913,7 +1913,7 @@ def test_create_archive_with_progress_calls_borg_with_progress_parameter():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         progress=True,
     )
 
@@ -1974,7 +1974,7 @@ def test_create_archive_with_progress_and_stream_processes_calls_borg_with_progr
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         progress=True,
         stream_processes=processes,
     )
@@ -2039,7 +2039,7 @@ def test_create_archive_with_stream_processes_ignores_read_special_false_and_log
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         stream_processes=processes,
     )
 
@@ -2107,7 +2107,7 @@ def test_create_archive_with_stream_processes_adds_special_files_to_excludes():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         stream_processes=processes,
     )
 
@@ -2172,7 +2172,7 @@ def test_create_archive_with_stream_processes_and_read_special_does_not_add_spec
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         stream_processes=processes,
     )
 
@@ -2213,7 +2213,7 @@ def test_create_archive_with_json_calls_borg_with_json_parameter():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         json=True,
     )
 
@@ -2256,7 +2256,7 @@ def test_create_archive_with_stats_and_json_calls_borg_without_stats_parameter()
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         json=True,
         stats=True,
     )
@@ -2304,7 +2304,7 @@ def test_create_archive_with_source_directories_glob_expands():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -2348,7 +2348,7 @@ def test_create_archive_with_non_matching_source_directories_glob_passes_through
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -2391,7 +2391,7 @@ def test_create_archive_with_glob_calls_borg_with_expanded_directories():
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -2434,7 +2434,7 @@ def test_create_archive_with_archive_name_format_calls_borg_with_archive_name():
         },
         storage_config={'archive_name_format': 'ARCHIVE_NAME'},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -2478,7 +2478,7 @@ def test_create_archive_with_archive_name_format_accepts_borg_placeholders():
         },
         storage_config={'archive_name_format': 'Documents_{hostname}-{now}'},  # noqa: FS003
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -2522,7 +2522,7 @@ def test_create_archive_with_repository_accepts_borg_placeholders():
         },
         storage_config={'archive_name_format': 'Documents_{hostname}-{now}'},  # noqa: FS003
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -2565,7 +2565,7 @@ def test_create_archive_with_extra_borg_options_calls_borg_with_extra_options():
         },
         storage_config={'extra_borg_options': {'create': '--extra --options'}},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
     )
 
 
@@ -2626,7 +2626,7 @@ def test_create_archive_with_stream_processes_calls_borg_with_processes_and_read
         },
         storage_config={},
         local_borg_version='1.2.3',
-        global_arguments=flexmock(log_json=False),
+        global_arguments=flexmock(log_json=False, used_config_paths=[]),
         stream_processes=processes,
     )
 
@@ -2652,7 +2652,7 @@ def test_create_archive_with_non_existent_directory_and_source_directories_must_
             },
             storage_config={},
             local_borg_version='1.2.3',
-            global_arguments=flexmock(log_json=False),
+            global_arguments=flexmock(log_json=False, used_config_paths=[]),
         )
 
 

--- a/tests/unit/borg/test_create.py
+++ b/tests/unit/borg/test_create.py
@@ -594,7 +594,11 @@ def test_create_archive_with_sources_and_used_config_paths_calls_borg_with_sourc
         ('foo', 'bar', '/etc/borgmatic/config.yaml')
     )
     flexmock(module).should_receive('map_directories_to_devices').and_return({})
-    flexmock(module).should_receive('expand_directories').and_return(())
+    flexmock(module).should_receive('expand_directories').with_args([]).and_return(())
+    flexmock(module).should_receive('expand_directories').with_args(
+        ('foo', 'bar', '/etc/borgmatic/config.yaml')
+    ).and_return(('foo', 'bar', '/etc/borgmatic/config.yaml'))
+    flexmock(module).should_receive('expand_directories').with_args([]).and_return(())
     flexmock(module).should_receive('pattern_root_directories').and_return([])
     flexmock(module.os.path).should_receive('expanduser').and_raise(TypeError)
     flexmock(module).should_receive('expand_home_directories').and_return(())

--- a/tests/unit/borg/test_create.py
+++ b/tests/unit/borg/test_create.py
@@ -586,6 +586,51 @@ def test_create_archive_with_patterns_calls_borg_with_patterns_including_convert
     )
 
 
+def test_create_archive_with_sources_and_used_config_paths_calls_borg_with_sources_and_config_paths():
+    flexmock(module.borgmatic.logger).should_receive('add_custom_log_levels')
+    flexmock(module.logging).ANSWER = module.borgmatic.logger.ANSWER
+    flexmock(module).should_receive('collect_borgmatic_source_directories').and_return([])
+    flexmock(module).should_receive('deduplicate_directories').and_return(
+        ('foo', 'bar', '/etc/borgmatic/config.yaml')
+    )
+    flexmock(module).should_receive('map_directories_to_devices').and_return({})
+    flexmock(module).should_receive('expand_directories').and_return(())
+    flexmock(module).should_receive('pattern_root_directories').and_return([])
+    flexmock(module.os.path).should_receive('expanduser').and_raise(TypeError)
+    flexmock(module).should_receive('expand_home_directories').and_return(())
+    flexmock(module).should_receive('write_pattern_file').and_return(None)
+    flexmock(module).should_receive('make_list_filter_flags').and_return('FOO')
+    flexmock(module.feature).should_receive('available').and_return(True)
+    flexmock(module).should_receive('ensure_files_readable')
+    flexmock(module).should_receive('make_pattern_flags').and_return(())
+    flexmock(module).should_receive('make_exclude_flags').and_return(())
+    flexmock(module.flags).should_receive('make_repository_archive_flags').and_return(
+        (f'repo::{DEFAULT_ARCHIVE_NAME}',)
+    )
+    environment = {'BORG_THINGY': 'YUP'}
+    flexmock(module.environment).should_receive('make_environment').and_return(environment)
+    flexmock(module).should_receive('execute_command').with_args(
+        ('borg', 'create') + REPO_ARCHIVE_WITH_PATHS + ('/etc/borgmatic/config.yaml',),
+        output_log_level=logging.INFO,
+        output_file=None,
+        borg_local_path='borg',
+        working_directory=None,
+        extra_environment=environment,
+    )
+
+    module.create_archive(
+        dry_run=False,
+        repository_path='repo',
+        location_config={
+            'source_directories': ['foo', 'bar'],
+            'repositories': ['repo'],
+        },
+        storage_config={},
+        local_borg_version='1.2.3',
+        global_arguments=flexmock(log_json=False, used_config_paths=['/etc/borgmatic/config.yaml']),
+    )
+
+
 def test_create_archive_with_exclude_patterns_calls_borg_with_excludes():
     flexmock(module.borgmatic.logger).should_receive('add_custom_log_levels')
     flexmock(module.logging).ANSWER = module.borgmatic.logger.ANSWER

--- a/tests/unit/commands/test_arguments.py
+++ b/tests/unit/commands/test_arguments.py
@@ -1,5 +1,6 @@
 import collections
 
+import pytest
 from flexmock import flexmock
 
 from borgmatic.commands import arguments as module
@@ -164,3 +165,13 @@ def test_parse_subparser_arguments_parses_borg_options_and_skips_other_subparser
     assert arguments == {'borg': action_namespace}
     assert arguments['borg'].options == ['list']
     assert remaining_arguments == []
+
+
+def test_parse_subparser_arguments_raises_error_when_no_subparser_is_specified():
+    action_namespace = flexmock(options=[])
+    subparsers = {
+        'config': flexmock(parse_known_args=lambda arguments: (action_namespace, ['config'])),
+    }
+
+    with pytest.raises(ValueError):
+        module.parse_subparser_arguments(('config',), subparsers)

--- a/tests/unit/commands/test_arguments.py
+++ b/tests/unit/commands/test_arguments.py
@@ -178,19 +178,32 @@ def test_parse_subparser_arguments_raises_error_when_no_subparser_is_specified()
 
 
 @pytest.mark.parametrize(
-    'arguments, unparsed_arguments, subparsers, expected_remaining_arguments',
-      [
+    'arguments, expected',
+    [
         (
-            {'action': flexmock()},
-            ['--verbosity', 'lots'],
-            {'action': flexmock(parse_known_args=lambda arguments: (flexmock(), ['--verbosity', 'lots']))},
-            ['--verbosity', 'lots'],
+            (
+                ('--latest', 'archive', 'prune', 'extract', 'list', '--test-flag'),
+                ('--latest', 'archive', 'check', 'extract', 'list', '--test-flag'),
+                ('prune', 'check', 'list', '--test-flag'),
+                ('prune', 'check', 'extract', '--test-flag'),
+            ),
+            [
+                '--test-flag',
+            ],
         ),
+        (
+            (
+                ('--latest', 'archive', 'prune', 'extract', 'list'),
+                ('--latest', 'archive', 'check', 'extract', 'list'),
+                ('prune', 'check', 'list'),
+                ('prune', 'check', 'extract'),
+            ),
+            [],
+        ),
+        ((), []),
     ],
 )
-def test_get_remaining_arguments_returns_expected_remaining_arguments(
-    arguments, unparsed_arguments, subparsers, expected_remaining_arguments
+def test_get_unparsable_arguments_returns_remaining_arguments_that_no_subparser_can_parse(
+    arguments, expected
 ):
-    remaining_arguments = module.get_remaining_arguments(arguments, unparsed_arguments, subparsers)
-
-    assert remaining_arguments == expected_remaining_arguments
+    assert module.get_unparsable_arguments(arguments) == expected

--- a/tests/unit/commands/test_arguments.py
+++ b/tests/unit/commands/test_arguments.py
@@ -175,3 +175,22 @@ def test_parse_subparser_arguments_raises_error_when_no_subparser_is_specified()
 
     with pytest.raises(ValueError):
         module.parse_subparser_arguments(('config',), subparsers)
+
+
+@pytest.mark.parametrize(
+    'arguments, unparsed_arguments, subparsers, expected_remaining_arguments',
+      [
+        (
+            {'action': flexmock()},
+            ['--verbosity', 'lots'],
+            {'action': flexmock(parse_known_args=lambda arguments: (flexmock(), ['--verbosity', 'lots']))},
+            ['--verbosity', 'lots'],
+        ),
+    ],
+)
+def test_get_remaining_arguments_returns_expected_remaining_arguments(
+    arguments, unparsed_arguments, subparsers, expected_remaining_arguments
+):
+    remaining_arguments = module.get_remaining_arguments(arguments, unparsed_arguments, subparsers)
+
+    assert remaining_arguments == expected_remaining_arguments

--- a/tests/unit/commands/test_borgmatic.py
+++ b/tests/unit/commands/test_borgmatic.py
@@ -987,6 +987,22 @@ def test_collect_configuration_run_summary_logs_info_for_success_with_extract():
     assert {log.levelno for log in logs} == {logging.INFO}
 
 
+def test_collect_configuration_run_summary_logs_info_for_success_with_bootstrap():
+    flexmock(module.validate).should_receive('guard_single_repository_selected').never()
+    flexmock(module.validate).should_receive('guard_configuration_contains_repository').never()
+    flexmock(module).should_receive('run_configuration').never()
+    flexmock(module.borgmatic.actions.config.bootstrap).should_receive('run_bootstrap')
+    arguments = {
+        'bootstrap': flexmock(repository='repo'),
+        'global': flexmock(monitoring_verbosity=1, dry_run=False),
+    }
+
+    logs = tuple(
+        module.collect_configuration_run_summary_logs({'test.yaml': {}}, arguments=arguments)
+    )
+    assert {log.levelno for log in logs} == {logging.INFO}
+
+
 def test_collect_configuration_run_summary_logs_extract_with_repository_error():
     flexmock(module.validate).should_receive('guard_configuration_contains_repository').and_raise(
         ValueError

--- a/tests/unit/commands/test_borgmatic.py
+++ b/tests/unit/commands/test_borgmatic.py
@@ -1002,6 +1002,7 @@ def test_collect_configuration_run_summary_logs_info_for_success_with_bootstrap(
     )
     assert {log.levelno for log in logs} == {logging.INFO}
 
+
 def test_collect_configuration_run_summary_logs_error_on_bootstrap_failure():
     flexmock(module.validate).should_receive('guard_single_repository_selected').never()
     flexmock(module.validate).should_receive('guard_configuration_contains_repository').never()

--- a/tests/unit/commands/test_borgmatic.py
+++ b/tests/unit/commands/test_borgmatic.py
@@ -1002,6 +1002,24 @@ def test_collect_configuration_run_summary_logs_info_for_success_with_bootstrap(
     )
     assert {log.levelno for log in logs} == {logging.INFO}
 
+def test_collect_configuration_run_summary_logs_error_on_bootstrap_failure():
+    flexmock(module.validate).should_receive('guard_single_repository_selected').never()
+    flexmock(module.validate).should_receive('guard_configuration_contains_repository').never()
+    flexmock(module).should_receive('run_configuration').never()
+    flexmock(module.borgmatic.actions.config.bootstrap).should_receive('run_bootstrap').and_raise(
+        ValueError
+    )
+    arguments = {
+        'bootstrap': flexmock(repository='repo'),
+        'global': flexmock(monitoring_verbosity=1, dry_run=False),
+    }
+
+    logs = tuple(
+        module.collect_configuration_run_summary_logs({'test.yaml': {}}, arguments=arguments)
+    )
+
+    assert {log.levelno for log in logs} == {logging.CRITICAL}
+
 
 def test_collect_configuration_run_summary_logs_extract_with_repository_error():
     flexmock(module.validate).should_receive('guard_configuration_contains_repository').and_raise(


### PR DESCRIPTION
From [#697](https://projects.torsion.org/borgmatic-collective/borgmatic/issues/697)

> you need the output of borgmatic/config/collect.py:collect_config_filenames()

🤦 I thought this function will just return the filename and not the complete path (since we use the word "path" in and around these files too).


This should store the config used to create an archive inside the archive itself.

TODO:
- [x] Create a `~/.borgmatic/bootstrap/configs-list.json` file.
- [ ] Update tests

![image](https://github.com/borgmatic-collective/borgmatic/assets/41837037/af105f01-9e24-47ef-a02a-bce7697cb869)
