### PR TITLE
Update systemd .service example

### DIFF
--- a/sample/systemd/borgmatic.service
+++ b/sample/systemd/borgmatic.service
@@ -32,16 +32,16 @@ RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
 SystemCallErrorNumber=EPERM
-# To restrict write access further, change "ProtectSystem" to "strict" and uncomment
-# "ReadWritePaths", "ReadOnlyPaths", "ProtectHome", and "BindPaths". Then add any local repository
-# paths to the list of "ReadWritePaths" and local backup source paths to "ReadOnlyPaths". This
-# leaves most of the filesystem read-only to borgmatic.
+# To restrict write access further, change "ProtectSystem" to "strict" and
+# uncomment "ReadWritePaths", "TemporaryFileSystem", "BindPaths" and
+# "BindReadOnlyPaths". Then add any local repository paths to the list of
+# "ReadWritePaths". This leaves most of the filesystem read-only to borgmatic.
 ProtectSystem=full
 # ReadWritePaths=-/mnt/my_backup_drive
-# ReadOnlyPaths=-/var/lib/my_backup_source
 # This will mount a tmpfs on top of /root and pass through needed paths
-# ProtectHome=tmpfs
+# TemporaryFileSystem=/root:ro
 # BindPaths=-/root/.cache/borg -/root/.config/borg -/root/.borgmatic
+# BindReadOnlyPaths=-/root/.ssh
 
 # May interfere with running external programs within borgmatic hooks.
 CapabilityBoundingSet=CAP_DAC_READ_SEARCH CAP_NET_RAW


### PR DESCRIPTION
First, ProtectSystem=strict will make the entire file system hierarchy (except /dev, /proc/ and /sys) read-only, so separate ReadOnlyPaths= is not necessary.

Second, ProtectHome=tmpfs will not just mount an empty tmpfs on /root, but also on /home and /run/user. As it's likely quite common to want to backup /home, this seems like a footgun.

Finally, it's quite likely that borgbackup will want access to root's SSH keys in order to connect to remote backup servers.

Note that all these options are commented out by default, so this is more of a documentation change than any real change in functionality.