### PR TITLE
Custom dump command for mysql

### DIFF
--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -1092,15 +1092,15 @@ properties:
                     description: |
                         Command to use instead of "mysqldump". This can be used
                         to run a specific mysql_dump version (e.g., one inside 
-                        a running docker container). Defaults to "mysqldump".
+                        a running container). Defaults to "mysqldump".
                     example: docker exec mysql_container mysqldump
                 mysql_command:
                     type: string
                     description: |
                         Command to run instead of "mysql". This
                         can be used to run a specific mysql
-                        version (e.g., one inside a running docker
-                        container). Defaults to "mysql".
+                        version (e.g., one inside a running container). 
+                        Defaults to "mysql".
                     example: docker exec mysql_container mysql
                 format:
                     type: string

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -971,6 +971,22 @@ properties:
                         a password will only work if MariaDB is configured to
                         trust the configured username without a password.
                     example: trustsome1
+                mariadb_dump_command:
+                    type: string
+                    description: |
+                        Command to use instead of "mariadb-dump". This can 
+                        be used to run a specific mariadb_dump version 
+                        (e.g., one inside a running container). 
+                        Defaults to "mariadb-dump".
+                    example: docker exec mariadb_container mariadb-dump
+                mariadb_command:
+                    type: string
+                    description: |
+                        Command to run instead of "mariadb". This
+                        can be used to run a specific mariadb
+                        version (e.g., one inside a running container). 
+                        Defaults to "mariadb".
+                    example: docker exec mariadb_container mariadb           
                 restore_password:
                     type: string
                     description: |

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -1087,6 +1087,21 @@ properties:
                         Password with which to connect to the restore database.
                         Defaults to the "password" option.
                     example: trustsome1
+                mysql_dump_command:
+                    type: string
+                    description: |
+                        Command to use instead of "mysqldump". This can be used
+                        to run a specific mysql_dump version (e.g., one inside 
+                        a running docker container). Defaults to "mysqldump".
+                    example: docker exec mysql_container mysqldump
+                mysql_command:
+                    type: string
+                    description: |
+                        Command to run instead of "mysql". This
+                        can be used to run a specific mysql
+                        version (e.g., one inside a running docker
+                        container). Defaults to "mysql".
+                    example: docker exec mysql_container mysql
                 format:
                     type: string
                     enum: ['sql']

--- a/borgmatic/hooks/mysql.py
+++ b/borgmatic/hooks/mysql.py
@@ -79,8 +79,9 @@ def execute_dump_command(
         )
         return None
 
+    mysql_dump_command = database.get('mysql_dump_command') or 'mysqldump'
     dump_command = (
-        ('mysqldump',)
+        (mysql_dump_command,)
         + (tuple(database['options'].split(' ')) if 'options' in database else ())
         + (('--add-drop-database',) if database.get('add_drop_database', True) else ())
         + (('--host', database['hostname']) if 'hostname' in database else ())
@@ -206,9 +207,9 @@ def restore_data_source_dump(
     password = connection_params['password'] or data_source.get(
         'restore_password', data_source.get('password')
     )
-
+    mysql_restore_command = data_source.get('mysql_command') or 'mysql'
     restore_command = (
-        ('mysql', '--batch')
+        (mysql_restore_command, '--batch')
         + (
             tuple(data_source['restore_options'].split(' '))
             if 'restore_options' in data_source

--- a/borgmatic/hooks/mysql.py
+++ b/borgmatic/hooks/mysql.py
@@ -35,8 +35,9 @@ def database_names_to_dump(database, extra_environment, log_prefix, dry_run):
     if dry_run:
         return ()
 
+    mysql_show_command = database.get('mysql_command') or 'mysql'
     show_command = (
-        ('mysql',)
+        (mysql_show_command,)
         + (tuple(database['list_options'].split(' ')) if 'list_options' in database else ())
         + (('--host', database['hostname']) if 'hostname' in database else ())
         + (('--port', str(database['port'])) if 'port' in database else ())

--- a/borgmatic/hooks/mysql.py
+++ b/borgmatic/hooks/mysql.py
@@ -35,7 +35,7 @@ def database_names_to_dump(database, extra_environment, log_prefix, dry_run):
         return (database['name'],)
     if dry_run:
         return ()
-    
+
     mysql_show_command = tuple(
         shlex.quote(part) for part in shlex.split(database.get('mysql_command') or 'mysql')
     )
@@ -82,7 +82,7 @@ def execute_dump_command(
             f'{log_prefix}: Skipping duplicate dump of MySQL database "{database_name}" to {dump_filename}'
         )
         return None
-    
+
     mysql_dump_command = tuple(
         shlex.quote(part) for part in shlex.split(database.get('mysql_dump_command') or 'mysqldump')
     )

--- a/tests/unit/hooks/test_mysql.py
+++ b/tests/unit/hooks/test_mysql.py
@@ -142,6 +142,27 @@ def test_database_names_to_dump_runs_mysql_with_list_options():
     assert module.database_names_to_dump(database, None, 'test.yaml', '') == ('foo', 'bar')
 
 
+def test_database_names_to_dump_runs_non_default_mysql_with_list_options():
+    database = {
+        'name': 'all',
+        'list_options': '--defaults-extra-file=my.cnf',
+        'mysql_command': 'custom_mysql',
+    }
+    flexmock(module).should_receive('execute_command_and_capture_output').with_args(
+        extra_environment=None,
+        full_command=(
+            'custom_mysql',  # Custom MySQL command
+            '--defaults-extra-file=my.cnf',
+            '--skip-column-names',
+            '--batch',
+            '--execute',
+            'show schemas',
+        )
+    ).and_return(('foo\nbar')).once()
+
+    assert module.database_names_to_dump(database, None, 'test.yaml', '') == ('foo', 'bar')
+
+
 def test_execute_dump_command_runs_mysqldump():
     process = flexmock()
     flexmock(module.dump).should_receive('make_data_source_dump_filename').and_return('dump')

--- a/tests/unit/hooks/test_mysql.py
+++ b/tests/unit/hooks/test_mysql.py
@@ -157,7 +157,7 @@ def test_database_names_to_dump_runs_non_default_mysql_with_list_options():
             '--batch',
             '--execute',
             'show schemas',
-        )
+        ),
     ).and_return(('foo\nbar')).once()
 
     assert module.database_names_to_dump(database, None, 'test.yaml', '') == ('foo', 'bar')

--- a/tests/unit/hooks/test_mysql.py
+++ b/tests/unit/hooks/test_mysql.py
@@ -315,6 +315,42 @@ def test_execute_dump_command_runs_mysqldump_with_options():
     )
 
 
+def test_execute_dump_command_runs_non_default_mysqldump():
+    process = flexmock()
+    flexmock(module.dump).should_receive('make_data_source_dump_filename').and_return('dump')
+    flexmock(module.os.path).should_receive('exists').and_return(False)
+    flexmock(module.dump).should_receive('create_named_pipe_for_dump')
+
+    flexmock(module).should_receive('execute_command').with_args(
+        (
+            'custom_mysqldump',  # Custom MySQL dump command
+            '--add-drop-database',
+            '--databases',
+            'foo',
+            '--result-file',
+            'dump',
+        ),
+        extra_environment=None,
+        run_to_completion=False,
+    ).and_return(process).once()
+
+    assert (
+        module.execute_dump_command(
+            database={
+                'name': 'foo',
+                'mysql_dump_command': 'custom_mysqldump',
+            },  # Custom MySQL dump command specified
+            log_prefix='log',
+            dump_path=flexmock(),
+            database_names=('foo',),
+            extra_environment=None,
+            dry_run=False,
+            dry_run_label='',
+        )
+        == process
+    )
+
+
 def test_execute_dump_command_with_duplicate_dump_skips_mysqldump():
     flexmock(module.dump).should_receive('make_data_source_dump_filename').and_return('dump')
     flexmock(module.os.path).should_receive('exists').and_return(True)
@@ -413,6 +449,34 @@ def test_restore_data_source_dump_runs_mysql_with_options():
 
     flexmock(module).should_receive('execute_command_with_processes').with_args(
         ('mysql', '--batch', '--harder'),
+        processes=[extract_process],
+        output_log_level=logging.DEBUG,
+        input_file=extract_process.stdout,
+        extra_environment=None,
+    ).once()
+
+    module.restore_data_source_dump(
+        hook_config,
+        {},
+        'test.yaml',
+        data_source=hook_config[0],
+        dry_run=False,
+        extract_process=extract_process,
+        connection_params={
+            'hostname': None,
+            'port': None,
+            'username': None,
+            'password': None,
+        },
+    )
+
+
+def test_restore_data_source_dump_runs_non_default_mysql_with_options():
+    hook_config = [{'name': 'foo', 'mysql_command': 'custom_mysql', 'restore_options': '--harder'}]
+    extract_process = flexmock(stdout=flexmock())
+
+    flexmock(module).should_receive('execute_command_with_processes').with_args(
+        ('custom_mysql', '--batch', '--harder'),
         processes=[extract_process],
         output_log_level=logging.DEBUG,
         input_file=extract_process.stdout,


### PR DESCRIPTION
Related Issue:
[https://projects.torsion.org/borgmatic-collective/borgmatic/issues/311](url)

Motivation and Context
Lets you run custom dump and restore commands for mysql to specify path for dump/restore binaries.

How Has This Been Tested?
Tested by me locally. I am able to run custom commands.

Types of change: New Feature

I have added tests to cover my changes.
