### PR TITLE
Fix color configuration directive

### DIFF
--- a/borgmatic/logger.py
+++ b/borgmatic/logger.py
@@ -38,7 +38,7 @@ def should_do_markup(no_color, configs):
     if no_color:
         return False
 
-    if any(config.get('output', {}).get('color') is False for config in configs.values()):
+    if any(config.get('color', True) is False for config in configs.values()):
         return False
 
     if os.environ.get('NO_COLOR', None):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -45,23 +45,27 @@ def test_interactive_console_true_when_isatty_and_TERM_is_not_dumb(capsys):
 
 
 def test_should_do_markup_respects_no_color_value():
+    flexmock(module).should_receive('interactive_console').never()
     assert module.should_do_markup(no_color=True, configs={}) is False
 
 
 def test_should_do_markup_respects_config_value():
-    assert (
-        module.should_do_markup(no_color=False, configs={'foo.yaml': {'output': {'color': False}}})
-        is False
-    )
+    flexmock(module).should_receive('interactive_console').never()
+    assert module.should_do_markup(no_color=False, configs={'foo.yaml': {'color': False}}) is False
+
+    flexmock(module).should_receive('interactive_console').and_return(True).once()
+    assert module.should_do_markup(no_color=False, configs={'foo.yaml': {'color': True}}) is True
 
 
 def test_should_do_markup_prefers_any_false_config_value():
+    flexmock(module).should_receive('interactive_console').never()
+
     assert (
         module.should_do_markup(
             no_color=False,
             configs={
-                'foo.yaml': {'output': {'color': True}},
-                'bar.yaml': {'output': {'color': False}},
+                'foo.yaml': {'color': True},
+                'bar.yaml': {'color': False},
             },
         )
         is False
@@ -80,25 +84,23 @@ def test_should_do_markup_respects_PY_COLORS_environment_variable():
 
 
 def test_should_do_markup_prefers_no_color_value_to_config_value():
-    assert (
-        module.should_do_markup(no_color=True, configs={'foo.yaml': {'output': {'color': True}}})
-        is False
-    )
+    flexmock(module).should_receive('interactive_console').never()
+
+    assert module.should_do_markup(no_color=True, configs={'foo.yaml': {'color': True}}) is False
 
 
 def test_should_do_markup_prefers_config_value_to_environment_variables():
     flexmock(module.os.environ).should_receive('get').and_return('True')
     flexmock(module).should_receive('to_bool').and_return(True)
+    flexmock(module).should_receive('interactive_console').never()
 
-    assert (
-        module.should_do_markup(no_color=False, configs={'foo.yaml': {'output': {'color': False}}})
-        is False
-    )
+    assert module.should_do_markup(no_color=False, configs={'foo.yaml': {'color': False}}) is False
 
 
 def test_should_do_markup_prefers_no_color_value_to_environment_variables():
     flexmock(module.os.environ).should_receive('get').and_return('True')
     flexmock(module).should_receive('to_bool').and_return(True)
+    flexmock(module).should_receive('interactive_console').never()
 
     assert module.should_do_markup(no_color=True, configs={}) is False
 
@@ -124,6 +126,7 @@ def test_should_do_markup_prefers_PY_COLORS_to_interactive_console_value():
 def test_should_do_markup_prefers_NO_COLOR_to_interactive_console_value():
     flexmock(module.os.environ).should_receive('get').with_args('PY_COLORS', None).and_return(None)
     flexmock(module.os.environ).should_receive('get').with_args('NO_COLOR', None).and_return('True')
+    flexmock(module).should_receive('interactive_console').never()
 
     assert module.should_do_markup(no_color=False, configs={}) is False
 
@@ -131,6 +134,7 @@ def test_should_do_markup_prefers_NO_COLOR_to_interactive_console_value():
 def test_should_do_markup_respects_NO_COLOR_environment_variable():
     flexmock(module.os.environ).should_receive('get').with_args('NO_COLOR', None).and_return('True')
     flexmock(module.os.environ).should_receive('get').with_args('PY_COLORS', None).and_return(None)
+    flexmock(module).should_receive('interactive_console').never()
 
     assert module.should_do_markup(no_color=False, configs={}) is False
 
@@ -150,6 +154,7 @@ def test_should_do_markup_prefers_NO_COLOR_to_PY_COLORS():
     flexmock(module.os.environ).should_receive('get').with_args('NO_COLOR', None).and_return(
         'SomeValue'
     )
+    flexmock(module).should_receive('interactive_console').never()
 
     assert module.should_do_markup(no_color=False, configs={}) is False
 


### PR DESCRIPTION
The `color` configuration directive is not taken into account and the output is shown as colored even when color is set to false in the configuration file.

This PR fixes the `color` configuration directive within the logger to read the actual value.

### How to reproduce ?

1. Set `color: false` in borgmatic configuration file
2. Run `borgmatic config validate`


### Environement

```
~ $ borgmatic --version
1.8.13
~ $ cat $HOME/.config/borgmatic/config.yaml|grep color:
color: false
```

### Before

![image](https://github.com/user-attachments/assets/62106965-fb98-464f-bf0a-d324ecbba28a)

### After

![image](https://github.com/user-attachments/assets/b199c6e2-a87c-4d3d-89c5-97a9543874d4)

