### PR TITLE
Improve logical volume discovery

### DIFF
--- a/borgmatic/hooks/data_source/snapshot.py
+++ b/borgmatic/hooks/data_source/snapshot.py
@@ -25,6 +25,5 @@ def get_contained_directories(parent_directory, candidate_contained_directories)
         if pathlib.PurePath(parent_directory) == pathlib.PurePath(candidate)
         or pathlib.PurePath(parent_directory) in pathlib.PurePath(candidate).parents
     )
-    candidate_contained_directories -= set(contained)
 
     return contained


### PR DESCRIPTION
The logical volume discovery algorithm is not yet capable to detect such a setup where mount point of one logical volume is located "under" the mount point of another logical volume (i.e. '/' and '/home')

config.yaml
```
source_directories:
    - /
    - /home
```
lsblk output
```
{
   "blockdevices": [
      {
         "name": "vg-root",
         "path": "/dev/mapper/vg-root",
         "mountpoint": "/",
         "type": "lvm"
      },{
         "name": "vg-home",
         "path": "/dev/mapper/vg-home",
         "mountpoint": "/home",
         "type": "lvm"
      }
   ]
}
```
current get_logical_volumes output
```
(Logical_volume(name='vg-root', device_path='/dev/mapper/vg-root', mount_point='/', contained_source_directories=('/', '/home')),)
```
expected get_logical_volumes output
```
(
Logical_volume(name='vg-root', device_path='/dev/mapper/vg-root', mount_point='/', contained_source_directories=('/',)),
Logical_volume(name='vg-home', device_path='/dev/mapper/vg-home', mount_point='/home', contained_source_directories=('/home',))
)
```