### PR TITLE
Fix path handling error when handling btrfs '/' submodule

### DIFF
--- a/borgmatic/hooks/data_source/btrfs.py
+++ b/borgmatic/hooks/data_source/btrfs.py
@@ -303,7 +303,6 @@ def remove_data_source_dumps(hook_config, config, borgmatic_runtime_directory, d
             snapshot_parent_dir = snapshot_path.rsplit(subvolume.path, 1)[0]
             if os.path.isdir(snapshot_parent_dir):
                 shutil.rmtree(snapshot_parent_dir)
-                continue
 
 
 def make_data_source_dump_patterns(

--- a/borgmatic/hooks/data_source/btrfs.py
+++ b/borgmatic/hooks/data_source/btrfs.py
@@ -299,9 +299,11 @@ def remove_data_source_dumps(hook_config, config, borgmatic_runtime_directory, d
                 logger.debug(error)
                 return
 
-            # Strip off the subvolume path from the end of the snapshot path and then delete the
-            # resulting directory.
-            shutil.rmtree(snapshot_path.rsplit(subvolume.path, 1)[0])
+            # Remove snapshot parent directory if it still exists (might not exist if snapshot was for '/')
+            snapshot_parent_dir = snapshot_path.rsplit(subvolume.path, 1)[0]
+            if os.path.isdir(snapshot_parent_dir):
+                shutil.rmtree(snapshot_parent_dir)
+                continue
 
 
 def make_data_source_dump_patterns(


### PR DESCRIPTION
Problem:

`borgmatic` is trying to remove directory '' (empty string), if configured to use btrfs snapshots, and data from '/' subvolume is included in the backup.

It would look like this with '--verbosity 2':

```
backupserver: Calling bootstrap hook function remove_data_source_dumps
backupserver: Looking for bootstrap manifest files to remove in /tmp/borgmatic-*/borgmatic/bootstrap
backupserver: Calling btrfs hook function remove_data_source_dumps
backupserver: findmnt -t btrfs --json --list
backupserver: Looking for snapshots to remove in /var/log/.borgmatic-snapshot-*/var/log
backupserver: Looking for snapshots to remove in /var/cache/.borgmatic-snapshot-*/var/cache
backupserver: Looking for snapshots to remove in /swap/.borgmatic-snapshot-*/swap
backupserver: Looking for snapshots to remove in /home/.borgmatic-snapshot-*/home
backupserver: Looking for snapshots to remove in /.borgmatic-snapshot-*
backupserver: Deleting Btrfs snapshot /.borgmatic-snapshot-108534
backupserver: btrfs subvolume delete /.borgmatic-snapshot-108534
Delete subvolume 329 (no-commit): '//.borgmatic-snapshot-108534'
backupserver: Error running actions for repository
backupserver: [Errno 2] No such file or directory: ''
```

occurs when:
- `btrfs:` section is present in config.
- data from `/` (like `/etc`) is backed up, or if bootstrapping is enabled.

Version: 
extra/borgmatic 1.9.10-1 (Arch)
