### PR TITLE
Add "verify_tls" option to Uptime Kuma hook.

### DIFF
--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -2200,6 +2200,12 @@ properties:
                     - start
                     - finish
                     - fail
+            verify_tls:
+                type: boolean
+                description: |
+                    Verify the TLS certificate of the push URL host. Defaults to
+                    true.
+                example: false
         description: |
             Configuration for a monitoring integration with Uptime Kuma using
             the Push monitor type.

--- a/borgmatic/hooks/monitoring/uptime_kuma.py
+++ b/borgmatic/hooks/monitoring/uptime_kuma.py
@@ -37,7 +37,7 @@ def ping_monitor(hook_config, config, config_filename, state, monitoring_log_lev
     logging.getLogger('urllib3').setLevel(logging.ERROR)
 
     try:
-        response = requests.get(f'{push_url}?{query}')
+        response = requests.get(f'{push_url}?{query}', verify=hook_config.get('verify_tls', True))
         if not response.ok:
             response.raise_for_status()
     except requests.exceptions.RequestException as error:


### PR DESCRIPTION
The option to skip tls verification allows the uptime kuma hook to work when the instance uses a self signed certificate in homelab or testing setups.